### PR TITLE
Created german translation

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,6 +29,7 @@ $page = 'templatedata';
 
 							<div id="lang-box">
 								<select id="lang-select">
+									<option value="de">Deutsch</option>
 									<option value="en">English</option>
 									<option value="es">Español</options>
 									<option value="fr">Français</option>
@@ -119,6 +120,7 @@ $page = 'templatedata';
 									<li>French (Français): <a href="https://en.wikipedia.org/wiki/User:Rastus_Vernon">Rastus Vernon</a></li>
 									<li>Hebrew (עברית): Eran Roz (<a href="https://he.wikipedia.org/wiki/%D7%9E%D7%A9%D7%AA%D7%9E%D7%A9:%D7%A2%D7%A8%D7%9F">ערן</a>)</li>
 									<li>Spanish (Español): <a href="https://pt.wikipedia.org/wiki/Usu%C3%A1rio:F%C3%BAlvio">Fúlvio</a></li>
+									<li>German (Deutsch): Rillke</li>
 								</ul>
 							</section>
 						</div>

--- a/js/params.js
+++ b/js/params.js
@@ -398,7 +398,9 @@ function templatedata(collection, description) {
 
 function importData(input) {
 	try {
-		var data = $.parseJSON( input );
+		var data = input.replace(/^\s*<templatedata(?:\s.*?)?>/i, '')
+				.replace(/\s*<\/templatedata\s*>\s*$/i, '');
+		data = $.parseJSON( data );
 	} catch (err) {
 		return;
 	}

--- a/js/params.js
+++ b/js/params.js
@@ -399,7 +399,8 @@ function templatedata(collection, description) {
 function importData(input) {
 	try {
 		var data = input.replace(/^\s*<templatedata(?:\s.*?)?>/i, '')
-				.replace(/\s*<\/templatedata\s*>\s*$/i, '');
+				.replace(/<\/templatedata\s*>\s*$/i, '')
+				.replace(/^\s+|\s+$/g, '');
 		data = $.parseJSON( data );
 	} catch (err) {
 		return;

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -1,0 +1,42 @@
+{
+	"headers": {
+		"page": "TemplateData Editor",
+		"desc": "Beschreibung",
+		"params": "Parameter",
+		"result": "Ergebnis"
+	},
+	"placeholders": {
+		"desc": "Vorlagenbeschreibung"
+	},
+	"table": {
+		"label": "Label",
+		"tipLabel": "Was dem Benutzer angezeigt wird",
+		"name": "Name",
+		"tipName": "Tatsächlicher Name",
+		"desc": "Beschreibung",
+		"type": "Typ",
+		"default": "Standard",
+		"required": "Benötigt",
+		"actions": "Aktionen",
+		"add": "Hinzufügen",
+		"import": "Importieren",
+		"import-append": "Anfügen",
+		"import-replace": "Ersetzen",
+		"import-info": "Füge hier die bereits vorhandenen TemplateData ein, aber ohne <code>&lttemplatedata&gt</code> <code>&lt/templatedata&gt</code>. Diese werden an das Ende der Tabelle angefügt",
+		"import-info-replace": "Füge hier die bereits vorhandenen TemplateData ein, aber ohne <code>&lttemplatedata&gt</code> <code>&lt/templatedata&gt</code>. <strong>Diese werden alle Tabellendaten ersetzen!</strong>",
+		"dup": "Duplizieren",
+		"dup-below": "darunter",
+		"dup-end": "an das Ende",
+		"del": "Löschen",
+		"param-name-header": "Name <small>/ Aliasnamen</small>",
+		"param-name-help": "Gib die Parameternamen in separaten Zeilen ein. Der Erste wird zum Hauptparameternamen, die Folgenden zu Aliasnamen.",
+		"save": "Speichern",
+		"cancel": "Abbrechen",
+		"type-unknown": "unbekannt",
+		"type-number": "Zahl",
+		"type-string": "Zeichenkette",
+		"type-user": "Benutzername",
+		"type-page": "Seite",
+		"empty-placeholder": "leer"
+	}
+}


### PR DESCRIPTION
As per http://tools.wikimedia.pl/~mlazowik/templatedata/

P.S.
Would it be better to rename `Type` to `Datatype`?

Why this reminder: "without <code>&lttemplatedata&gt</code>"? Simply trim it away, removing a lot of blah blah from the User Interface.
